### PR TITLE
Switch back to containerized builds on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
   - mysql -u root -e "GRANT ALL PRIVILEGES ON *.* TO 'travis'@'localhost'"
   - mysql -u root -e "create database if not exists test default charset utf8;"
 
-script: ./gradlew build
+before_deploy: ./gradlew build
 
 deploy:
   provider: gae

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,29 @@
 language: java
-sudo: required
+
 jdk:
-- oraclejdk8
+  - oraclejdk8
+
 services:
-- mysql
-- docker
+  - mysql
+
 before_cache:
   - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock
+
 cache:
   directories:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
+
 before_install:
-- $(! $TRAVIS_SECURE_ENV_VARS) || (openssl aes-256-cbc -K $encrypted_e55aacca67f1_key -iv $encrypted_e55aacca67f1_iv
-  -in secrets.tar.enc -out secrets.tar -d && tar xvf secrets.tar)
-- sudo apt-get -qq update
-- sudo apt-get -y install mariadb-server
-- mysql -u root -e "CREATE USER 'travis'@'%' IDENTIFIED BY ''"
-- mysql -u root -e "CREATE USER 'travis'@'localhost' IDENTIFIED BY ''"
-- mysql -u root -e "GRANT ALL PRIVILEGES ON *.* TO 'travis'@'%'"
-- mysql -u root -e "GRANT ALL PRIVILEGES ON *.* TO 'travis'@'localhost'"
-- mysql -u root -e "create database if not exists test default charset utf8;"
-script: "./gradlew build"
+  - $(! $TRAVIS_SECURE_ENV_VARS) || (openssl aes-256-cbc -K $encrypted_e55aacca67f1_key -iv $encrypted_e55aacca67f1_iv
+    -in secrets.tar.enc -out secrets.tar -d && tar xvf secrets.tar)
+  - mysql -u root -e "GRANT ALL PRIVILEGES ON *.* TO 'travis'@'%'"
+  - mysql -u root -e "GRANT ALL PRIVILEGES ON *.* TO 'travis'@'localhost'"
+  - mysql -u root -e "create database if not exists test default charset utf8;"
+
+script: ./gradlew build
+
 deploy:
   provider: gae
   project: coduno
   skip_cleanup: true
-  docker_build: local


### PR DESCRIPTION
By facilitating remote builds we do not need sudo anymore and can run on faster containerized infrastructure.

Also, I opted to use their MySQL service instead of rolling our own MariaDB (which required sudo in our old `.travis.yml` as well).

Also, `./gradlew build` will only be executed for builds that trigger a deployment, which could give a teeny tiny speed up. For builds that do not trigger a deployment, all tests will be triggered (`./gradlew check` is run).