### PR TITLE
CatCoder-Import can handle resource-file

### DIFF
--- a/platform-catcoder-game-importer/src/main/java/uno/cod/platform/server/codingcontest/sync/dto/PuzzleDto.java
+++ b/platform-catcoder-game-importer/src/main/java/uno/cod/platform/server/codingcontest/sync/dto/PuzzleDto.java
@@ -20,6 +20,9 @@ public class PuzzleDto {
     @JacksonXmlProperty(localName = "inputfile")
     private String inputFilePath;
 
+    @JacksonXmlProperty(localName = "resourcefile")
+    private String resourceFilePath;
+
     public String getCanonicalName() {
         return canonicalName;
     }
@@ -38,5 +41,9 @@ public class PuzzleDto {
 
     public String getValidationClass() {
         return validationClass;
+    }
+
+    public String getResourceFilePath() {
+        return resourceFilePath;
     }
 }

--- a/platform-server-kernel/src/main/java/uno/cod/platform/server/core/domain/NamedEntity.java
+++ b/platform-server-kernel/src/main/java/uno/cod/platform/server/core/domain/NamedEntity.java
@@ -5,7 +5,6 @@ import uno.cod.platform.server.core.Named;
 
 import javax.persistence.Column;
 import javax.persistence.MappedSuperclass;
-import java.io.Serializable;
 import java.util.UUID;
 
 @MappedSuperclass

--- a/platform-server-kernel/src/main/java/uno/cod/platform/server/core/service/ChallengeTemplateService.java
+++ b/platform-server-kernel/src/main/java/uno/cod/platform/server/core/service/ChallengeTemplateService.java
@@ -37,7 +37,7 @@ public class ChallengeTemplateService {
         this.endpointRepository = endpointRepository;
     }
 
-    public UUID save(ChallengeTemplateCreateDto dto) {
+    public String save(ChallengeTemplateCreateDto dto) {
         Organization organization = organizationRepository.findOne(dto.getOrganizationId());
         if (organization == null) {
             throw new CodunoIllegalArgumentException("organization.invalid");
@@ -59,7 +59,7 @@ public class ChallengeTemplateService {
         organization.addChallenge(challengeTemplate);
         endpoint.addChallenge(challengeTemplate);
 
-        return repository.save(challengeTemplate).getId();
+        return repository.save(challengeTemplate).getCanonicalName();
     }
 
     public ChallengeTemplateShowDto findById(UUID id) {

--- a/platform-server-kernel/src/main/java/uno/cod/platform/server/core/service/OrganizationService.java
+++ b/platform-server-kernel/src/main/java/uno/cod/platform/server/core/service/OrganizationService.java
@@ -4,7 +4,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uno.cod.platform.server.core.domain.Organization;
 import uno.cod.platform.server.core.domain.OrganizationMembership;
-import uno.cod.platform.server.core.domain.OrganizationMembershipKey;
 import uno.cod.platform.server.core.domain.User;
 import uno.cod.platform.server.core.dto.organization.OrganizationCreateDto;
 import uno.cod.platform.server.core.dto.organization.OrganizationShowDto;

--- a/platform-server-rest/src/main/java/uno/cod/platform/server/rest/controller/CatcoderGameImportController.java
+++ b/platform-server-rest/src/main/java/uno/cod/platform/server/rest/controller/CatcoderGameImportController.java
@@ -26,8 +26,8 @@ public class CatcoderGameImportController {
 
     @AllowedForAdmin
     @RequestMapping(value = RestUrls.CATCODER_GAME_UPLOAD, method = RequestMethod.POST)
-    public ResponseEntity<UUID> gameUploadZip(@RequestParam("file") MultipartFile file,
-                                              @RequestParam("organization") UUID organization) throws IOException {
+    public ResponseEntity<String> gameUploadZip(@RequestParam("file") MultipartFile file,
+                                                @RequestParam("organization") UUID organization) throws IOException {
         return new ResponseEntity<>(catcoderGameImportService.createChallengeTemplateFromGameResources(file, organization), HttpStatus.OK);
     }
 }

--- a/platform-server-rest/src/main/java/uno/cod/platform/server/rest/controller/ChallengeTemplateController.java
+++ b/platform-server-rest/src/main/java/uno/cod/platform/server/rest/controller/ChallengeTemplateController.java
@@ -28,7 +28,7 @@ public class ChallengeTemplateController {
 
     @RequestMapping(value = RestUrls.CHALLENGE_TEMPLATES, method = RequestMethod.POST)
     @PreAuthorize("isAuthenticated() and @securityService.isOrganizationAdmin(principal, #dto.organizationId)")
-    public ResponseEntity<UUID> create(@RequestBody ChallengeTemplateCreateDto dto) {
+    public ResponseEntity<String> create(@RequestBody ChallengeTemplateCreateDto dto) {
         return new ResponseEntity<>(service.save(dto), HttpStatus.CREATED);
     }
 

--- a/platform-storage-gcs/src/main/java/uno/cod/storage/gcs/GcsStorageDriver.java
+++ b/platform-storage-gcs/src/main/java/uno/cod/storage/gcs/GcsStorageDriver.java
@@ -91,6 +91,7 @@ public class GcsStorageDriver implements PlatformStorage {
 
     @Override
     public String uploadPublic(String bucket, String fileName, InputStream data, String contentType) throws IOException {
+        LOGGER.info("Uploading file " + fileName);
         InputStreamContent contentStream = new InputStreamContent(contentType, data);
         Storage.Objects.Insert insertObject = storage
                 .objects()


### PR DESCRIPTION
Some catcoder-games have additional resource files attached to a challenge (e.g. simulator)
This is done by providing a link to a zip file at the first level. In order to be able to import such
a game into Coduno, the CatcoderGameImportService now looks for such a resource-file in
the xml file of the challenge description. If found, the file is uploaded into a bucket and the
link is provided in the challenge-instructions.
Also, the ChallengeTemplateController respectively Service returns a String instead of a UUID
since this is needed for the app to redirect to the correct page.
As uploading files is the most time-consuming part when importing a challenge, the currently
uploaded filename is now logged.
