### PR TITLE
Task download restriction

### DIFF
--- a/platform-server-kernel/src/main/java/uno/cod/platform/server/core/service/ResultService.java
+++ b/platform-server-kernel/src/main/java/uno/cod/platform/server/core/service/ResultService.java
@@ -10,16 +10,12 @@ import uno.cod.platform.server.core.dto.result.ResultShowDto;
 import uno.cod.platform.server.core.dto.user.UserShortShowDto;
 import uno.cod.platform.server.core.exception.CodunoIllegalArgumentException;
 import uno.cod.platform.server.core.mapper.ResultMapper;
-import uno.cod.platform.server.core.repository.ChallengeRepository;
-import uno.cod.platform.server.core.repository.ParticipationRepository;
-import uno.cod.platform.server.core.repository.ResultRepository;
+import uno.cod.platform.server.core.repository.*;
 
+import javax.servlet.http.HttpSession;
 import javax.transaction.Transactional;
 import java.time.ZonedDateTime;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 
 @Service
 @Transactional
@@ -28,14 +24,21 @@ public class ResultService {
     private final ChallengeRepository challengeRepository;
     private final TaskScheduler taskScheduler;
     private final ParticipationRepository participationRepository;
+    private final HttpSession httpSession;
+
+    public static final String CURRENT_CHALLENGE = "CURRENT_CHALLENGE";
 
     @Autowired
     public ResultService(ResultRepository repository,
-                         ChallengeRepository challengeRepository, TaskScheduler taskScheduler, ParticipationRepository participationRepository) {
+                         ChallengeRepository challengeRepository,
+                         TaskScheduler taskScheduler,
+                         ParticipationRepository participationRepository,
+                         HttpSession httpSession) {
         this.repository = repository;
         this.challengeRepository = challengeRepository;
         this.taskScheduler = taskScheduler;
         this.participationRepository = participationRepository;
+        this.httpSession = httpSession;
     }
 
     public ResultShowDto save(UUID challengeId, User user) {
@@ -81,6 +84,7 @@ public class ResultService {
             repository.save(r);
         }, setFinished);
 
+        httpSession.setAttribute(CURRENT_CHALLENGE, challenge.getId());
         return ResultMapper.map(result);
     }
 
@@ -111,6 +115,7 @@ public class ResultService {
         if (result == null) {
             return null;
         }
+        httpSession.setAttribute(CURRENT_CHALLENGE, challengeId);
         return new ResultInfoDto(result);
     }
 }

--- a/platform-server-rest/src/main/java/uno/cod/platform/server/rest/controller/TaskController.java
+++ b/platform-server-rest/src/main/java/uno/cod/platform/server/rest/controller/TaskController.java
@@ -4,7 +4,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import uno.cod.platform.server.core.domain.User;
 import uno.cod.platform.server.core.dto.task.TaskCreateDto;
 import uno.cod.platform.server.core.dto.task.TaskShowDto;
 import uno.cod.platform.server.core.security.AllowedForAdmin;
@@ -32,8 +34,8 @@ public class TaskController {
 
     @RequestMapping(value = RestUrls.TASKS_ID, method = RequestMethod.GET)
     @PreAuthorize("isAuthenticated() and @securityService.canAccessTask(principal, #id)")
-    public ResponseEntity<TaskShowDto> findById(@PathVariable UUID id) {
-        return new ResponseEntity<>(taskService.findById(id), HttpStatus.OK);
+    public ResponseEntity<TaskShowDto> findById(@PathVariable UUID id, @AuthenticationPrincipal User user) {
+        return new ResponseEntity<>(taskService.findById(id, user), HttpStatus.OK);
     }
 
     @RequestMapping(value = RestUrls.TASKS, method = RequestMethod.GET, params = {"organization"})


### PR DESCRIPTION
When participating in a challenge, there are several tasks/levels. New tasks can only be shown
respectively downloaded when the previous challenge was submitted and produced the
correct results.
Previously, this was just handled on the client side and users could have downloaded the task
description of the next level by calling the corresponding API. This is not possible anymore as
the permission to download the file is now checked server-side.
This is done by setting a session attribute named "CURRENT_CHALLENGE" which is set when
the challenge is viewed and allows the server to quickly check in what level the user is.
